### PR TITLE
add community.vmware as a dependency

### DIFF
--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -3,3 +3,4 @@ collections:
   - name: https://github.com/ansible-collections/vmware.vmware.git
     type: git
     version: main
+  - name: community.vmware


### PR DESCRIPTION
Fixes `ERROR! couldn't resolve module/action 'community.vmware.vmware_guest'. This often indicates a misspelling, missing collection, or incorrect module path.`,
by adding a dependency on `community.vmware`

